### PR TITLE
fix: remove NODE_AUTH_TOKEN from publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,6 @@ jobs:
       - name: 📦 Publish
         run: |
           pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 📃 Create Release
         id: create_release


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN environment variable from publish step.