### PR TITLE
fix: pnpm publish に --ignore-scripts を追加して dist/ が公開パッケージに含まれるよう修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,11 @@ jobs:
       - name: 🗑️ Remove examples directory
         run: rm -rfv src/examples
 
-      - name: 🔍 Lint
-        run: pnpm run lint
-
       - name: 🏃 Build
         run: pnpm run build
+
+      - name: 🔍 Lint
+        run: pnpm run lint
 
       - name: 🏷 Bump version and push tag
         id: tag-version
@@ -81,12 +81,14 @@ jobs:
           pnpm version --no-git-tag-version ${{ steps.tag-version.outputs.new_version }}
 
       - name: 📦 Pack
+        id: pack
         run: |
-          pnpm pack --ignore-scripts
+          TARBALL=$(pnpm pack --ignore-scripts)
+          echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
       - name: 📦 Publish
         run: |
-          pnpm publish "$(ls book000-node-utils-*.tgz)" --access public --no-git-checks
+          pnpm publish "${{ steps.pack.outputs.tarball }}" --access public --no-git-checks
 
       - name: 📃 Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
       - name: 🗑️ Remove examples directory
         run: rm -rfv src/examples
 
+      - name: 🔍 Lint
+        run: pnpm run lint
+
       - name: 🏃 Build
         run: pnpm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: 📦 Publish
         run: |
-          pnpm publish --access public --no-git-checks
+          pnpm publish --access public --no-git-checks --ignore-scripts
 
       - name: 📃 Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,13 @@ jobs:
         run: |
           pnpm version --no-git-tag-version ${{ steps.tag-version.outputs.new_version }}
 
+      - name: 📦 Pack
+        run: |
+          pnpm pack --ignore-scripts
+
       - name: 📦 Publish
         run: |
-          pnpm publish --access public --no-git-checks --ignore-scripts
+          pnpm publish "$(ls book000-node-utils-*.tgz)" --access public --no-git-checks
 
       - name: 📃 Create Release
         id: create_release


### PR DESCRIPTION
## 問題

`@book000/node-utils` v1.24.124 以降、npm に公開されるパッケージに `dist/` ディレクトリが含まれていない。

これにより、このパッケージを依存として使用するすべてのプロジェクトで以下のエラーが発生している。

```
error TS2307: Cannot find module '@book000/node-utils' or its corresponding type declarations.
```

## 根本原因（GitHub Actions ログから特定）

### pnpm publish のライフサイクル実行順序

リリースワークフローの「Publish」ステップ (`pnpm publish --access public --no-git-checks`) を実行すると、pnpm v10.33.0 は以下の順序でライフサイクルスクリプトを実行する。

```
21:44:14  pnpm publish 開始
21:44:15  prepublishOnly → run-s lint → run-z lint:prettier,lint:eslint,lint:tsc（並列実行）
21:44:20  prepare → run-s build → run-s clean ctix compile  ← 問題の原因
21:44:20    clean: rimraf dist     ← dist/ を完全削除
21:44:21    ctix: src/index.ts 再生成
21:44:22.08 compile: tsc -p tsconfig.build.json 開始（完了まで約 3 秒要する）
21:44:23.19 パック（tarball 作成）← compile 開始から 1.1 秒後、完了前に実行！
21:44:24  npm registry に publish（dist/ なしで公開）
```

### レースコンディションの発生

pnpm が `prepare` ライフサイクルを非同期で起動した後、TypeScript コンパイル (`compile`) の完了を待たずにパック処理を実行する。

- `compile` (tsc) の開始: `21:44:22.083`
- パック実行: `21:44:23.189`（compile 開始の **1.1 秒後**）
- TypeScript コンパイルの実際の所要時間: 約 **2.9 秒**（同ワークフロー内の Build ステップ `21:44:07` → `21:44:10` より）

`clean` が `dist/` を削除済みの状態で、`compile` がまだ出力ファイルを生成し終えていない間にパックが実行されるため、tarball には `LICENSE`・`README.md`・`package.json` の 3 ファイルのみが含まれる。

### TypeScript 6 アップグレードで問題が表面化した理由

TypeScript v5.9.3 → v6.0.2 へのアップグレード（commit 471b540, PR #1378）で型チェックの処理量が増加し、コンパイル時間が約 1 秒以上延びた。

TypeScript 5 時代はコンパイルがパック前に完了していたため問題が発生しなかったが、TypeScript 6 でコンパイル時間が「パックまでの猶予時間 (1.1 秒)」を超えたことで、ビルド完了前にパックが走るレースコンディションが露見した。

## 修正内容

`pnpm publish` を `pnpm pack → pnpm publish <tarball>` の 2 ステップに分割する。

```yaml
- name: 📦 Pack
  run: |
    pnpm pack --ignore-scripts

- name: 📦 Publish
  run: |
    pnpm publish "$(ls book000-node-utils-*.tgz)" --access public --no-git-checks
```

1. `pnpm pack --ignore-scripts`: ライフサイクルスクリプトをスキップして tarball を生成。ワークフローの明示ビルドステップで生成した `dist/` がそのまま tarball に含まれる
2. `pnpm publish <tarball>`: 既製 tarball を公開するため、ライフサイクルスクリプトは実行されない

`prepublishOnly`（lint）を補うため、明示的な Lint ステップも追加している。

## 影響範囲

- v1.24.124 〜 v1.24.147（全バージョン）において `dist/` が公開パッケージに含まれていない
- この修正により、次のリリースから `dist/` が正しく含まれるようになる
- 影響を受けた消費プロジェクト（30 件以上）については、修正版リリース後に個別 PR を作成予定