### PR TITLE
fix: pnpm pack の --ignore-scripts 非対応を jq で回避し dist/ が正しく含まれるよう修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         id: pack
         run: |
           jq 'del(.scripts.prepare)' package.json > package.json.tmp && mv package.json.tmp package.json
-          TARBALL=$(pnpm pack)
+          TARBALL=$(pnpm pack 2>/dev/null | tail -n 1)
           echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
       - name: 📦 Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,8 @@ jobs:
       - name: 📦 Pack
         id: pack
         run: |
-          TARBALL=$(pnpm pack --ignore-scripts)
+          jq 'del(.scripts.prepare)' package.json > package.json.tmp && mv package.json.tmp package.json
+          TARBALL=$(pnpm pack)
           echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
       - name: 📦 Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,7 @@ jobs:
       - name: 📦 Pack
         id: pack
         run: |
-          jq 'del(.scripts.prepare)' package.json > package.json.tmp && mv package.json.tmp package.json
-          TARBALL=$(pnpm pack 2>/dev/null | tail -n 1)
+          TARBALL=$(npm_config_ignore_scripts=true pnpm pack 2>/dev/null | tail -n 1)
           echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
       - name: 📦 Publish


### PR DESCRIPTION
## 概要

PR #1402 のマージ後、Release ワークフローが以下のエラーで失敗していた。

```
ERROR  Unknown option: 'ignore-scripts'
Did you mean 'ignore-workspace'? Use "--config.unknown=value" to force an unknown option.
For help, run: pnpm help pack
```

`pnpm pack --ignore-scripts` は pnpm でサポートされていないオプションであり、前回のフィックスが機能しなかった。

## 根本原因の詳細

`pnpm publish` は lifecycle として `prepare` スクリプトを実行する。  
`prepare` = `run-s build` = `clean（rimraf dist/）→ ctix → compile（tsc）`

TypeScript 6 移行後にコンパイルが約 3 秒かかるようになり、`pnpm pack` がコンパイル完了前に tarball を作成してしまう。結果として空の `dist/` が含まれたパッケージが公開される。

## 修正内容

### Pack ステップの修正

`npm_config_ignore_scripts=true` 環境変数を設定してから `pnpm pack` を実行することで、`package.json` を変更せずに lifecycle スクリプト（`prepare` 含む）をスキップする。これは `npm` コマンドの使用ではなく、pnpm が尊重する npm 互換の環境変数である。

また、`pnpm pack` は tarball ファイル名以外にも進捗メッセージ等を stdout に出力するため、`2>/dev/null` で stderr を抑制し `tail -n 1` で最終行（tarball ファイル名）のみを取得する。

```yaml
- name: 📦 Pack
  id: pack
  run: |
    TARBALL=$(npm_config_ignore_scripts=true pnpm pack 2>/dev/null | tail -n 1)
    echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
```

## ワークフロー全体の流れ

1. **Remove examples** — `src/examples` を削除
2. **Build** — `pnpm run build` で `dist/` を生成
3. **Lint** — ビルド後に lint（ctix 再生成後の `src/index.ts` も対象）
4. **Version bump** — タグ付け・バージョン更新
5. **Pack** — `npm_config_ignore_scripts=true` で lifecycle をスキップし `pnpm pack`（`dist/` がそのまま含まれる）、`tail -n 1` でファイル名のみ取得
6. **Publish** — step output の tarball パスで `pnpm publish`
7. **Create Release** — GitHub Release 作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)