### PR TITLE
fix(ci): pnpm v11 の ERR_PNPM_UNCLEAN_WORKING_TREE エラーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,9 @@ jobs:
 
       - name: 📝 Update package.json version
         run: |
-          pnpm version --no-git-tag-version ${{ steps.tag-version.outputs.new_version }}
+          # pnpm v11 ではワーキングツリーが clean でないと pnpm version が拒否するため、
+          # --no-git-checks フラグを追加してチェックをスキップする
+          pnpm version --no-git-tag-version --no-git-checks ${{ steps.tag-version.outputs.new_version }}
 
       - name: 📦 Pack
         id: pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,6 @@ jobs:
       - name: 👨🏻‍💻 Install dependencies
         run: pnpm install --frozen-lockfile --prefer-frozen-lockfile
 
-      - name: 🗑️ Remove examples directory
-        run: rm -rfv src/examples
-
-      - name: 🏃 Build
-        run: pnpm run build
-
-      - name: 🔍 Lint
-        run: pnpm run lint
-
       - name: 🏷 Bump version and push tag
         id: tag-version
         uses: mathieudutour/github-tag-action@v6.2
@@ -78,9 +69,18 @@ jobs:
 
       - name: 📝 Update package.json version
         run: |
-          # pnpm v11 ではワーキングツリーが clean でないと pnpm version が拒否するため、
-          # --no-git-checks フラグを追加してチェックをスキップする
-          pnpm version --no-git-tag-version --no-git-checks ${{ steps.tag-version.outputs.new_version }}
+          # pnpm version を rm -rfv src/examples より前に実行することで、
+          # ワーキングツリーが clean な状態を保ちチェックをパスさせる
+          pnpm version --no-git-tag-version ${{ steps.tag-version.outputs.new_version }}
+
+      - name: 🗑️ Remove examples directory
+        run: rm -rfv src/examples
+
+      - name: 🏃 Build
+        run: pnpm run build
+
+      - name: 🔍 Lint
+        run: pnpm run lint
 
       - name: 📦 Pack
         id: pack


### PR DESCRIPTION
## 概要

pnpm v11 にアップグレード後、Release ワークフローで `pnpm version --no-git-tag-version` の実行が `ERR_PNPM_UNCLEAN_WORKING_TREE` エラーで失敗するようになった問題を修正します。

## 根本原因

ワークフローのステップ順序に問題がありました。

**修正前の順序:**

1. `pnpm install --frozen-lockfile`
2. **`rm -rfv src/examples`** ← 追跡ファイルを削除（ワーキングツリーが汚染される）
3. `pnpm run build`
4. `pnpm run lint`
5. `pnpm version --no-git-tag-version <version>` ← **汚染された状態で実行 → ERR_PNPM_UNCLEAN_WORKING_TREE**

`ctix` が `src/index.ts` を再生成する際に `src/examples/` ディレクトリが不要なため削除していますが、この削除操作（git 追跡ファイルの削除）によってワーキングツリーが汚染されます。pnpm v11 では `pnpm version` 実行時にワーキングツリーが clean でない場合にエラーを返すため、この順序では必ず失敗します。

> `package.json` の `files: ["dist"]` により `src/examples/` は npm パッケージに含まれませんが、ビルド前に削除しておく必要があります。

## 修正内容

`--no-git-checks` フラグを追加する対処療法ではなく、**ステップの実行順序を変更**することで根本修正します。

**修正後の順序:**

1. `pnpm install --frozen-lockfile`
2. **`🏷 Bump version and push tag`**（タグ決定）← 前に移動
3. **`📝 Update package.json version`**（`pnpm version --no-git-tag-version`）← clean な状態で実行
4. `rm -rfv src/examples`（ここでワーキングツリーが汚染されるが、version バンプは済んでいる）
5. `pnpm run build`
6. `pnpm run lint`

`pnpm version` をファイル削除より前に実行することで、ワーキングツリーが clean な状態を保ったままバージョン更新が行われます。

## 変更ファイル

- `.github/workflows/release.yml`
  - `🏷 Bump version and push tag` と `📝 Update package.json version` ステップを `🗑️ Remove examples directory` の前に移動
  - `pnpm version` から `--no-git-checks` フラグを削除

## 影響範囲

- `.github/workflows/release.yml` のみ変更
- 他のワークフロー（`nodejs-ci-pnpm.yml`）は再利用可能ワークフローを呼び出すだけのため影響なし

## 参考

- 失敗した run: https://github.com/book000/node-utils/actions/runs/26250790469
- pnpm v11 エラーコード一覧: https://pnpm.io/errors
- pnpm version コマンド: https://pnpm.io/cli/version