### PR TITLE
fix(ci): pnpm pack で dist/ が tarball に含まれない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,16 @@ jobs:
 
       - name: 📦 Pack
         id: pack
+        env:
+          npm_config_ignore_scripts: 'true'
         run: |
-          TARBALL=$(npm_config_ignore_scripts=true pnpm pack 2>/dev/null | tail -n 1)
-          echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
+          set -eo pipefail
+          TARBALL=$(pnpm pack --json | jq -r '.filename')
+          if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
+            echo "::error::Failed to determine packed tarball filename"
+            exit 1
+          fi
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Publish
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,9 @@ jobs:
 
       - name: 📦 Pack
         id: pack
-        env:
-          npm_config_ignore_scripts: 'true'
         run: |
           set -eo pipefail
-          TARBALL=$(pnpm pack --json | jq -r '.filename')
+          TARBALL=$(pnpm --config.ignore-scripts=true pack --json | jq -r '.filename')
           if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
             echo "::error::Failed to determine packed tarball filename"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,23 +79,27 @@ jobs:
       - name: 🏃 Build
         run: pnpm run build
 
+      - name: 🔍 Verify dist contents
+        run: |
+          test -f dist/index.js
+          test -f dist/index.d.ts
+
+      - name: 📦 Verify pack contents
+        run: |
+          mkdir -p /tmp/pack-check
+          pnpm pack --pack-destination /tmp/pack-check
+          TARBALL=$(ls /tmp/pack-check/*.tgz | head -1)
+          echo "Inspecting $TARBALL"
+          tar -tzf "$TARBALL" | tee /tmp/pack-files.txt
+          grep -q '^package/dist/index.js$' /tmp/pack-files.txt
+          grep -q '^package/dist/index.d.ts$' /tmp/pack-files.txt
+
       - name: 🔍 Lint
         run: pnpm run lint
 
-      - name: 📦 Pack
-        id: pack
-        run: |
-          set -eo pipefail
-          TARBALL=$(pnpm --config.ignore-scripts=true pack --json | jq -r '.filename')
-          if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
-            echo "::error::Failed to determine packed tarball filename"
-            exit 1
-          fi
-          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
-
       - name: 📦 Publish
         run: |
-          pnpm publish "${{ steps.pack.outputs.tarball }}" --access public --no-git-checks
+          pnpm publish --access public --no-git-checks --ignore-scripts
 
       - name: 📃 Create Release
         id: create_release

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "run-s clean ctix compile",
     "prepublishOnly": "run-s lint",
     "prepare": "run-s build",
-    "clean": "rimraf dist output",
+    "clean": "rimraf dist output tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "example": "tsx ./src/examples/main.ts",
     "lint:prettier": "prettier --check src",
     "lint:tsc": "tsc",


### PR DESCRIPTION
## 問題

v1.24.189 以降、npm に公開される tarball に `dist/` が含まれていない。11 件以上の利用プロジェクトで Renovate PR の CI が失敗している。

```bash
curl -sL "https://registry.npmjs.org/@book000/node-utils/-/node-utils-1.24.190.tgz" | tar -tz
# 出力:
# package/LICENSE
# package/package.json
# package/README.md
```

## 根本原因

`tsconfig.build.tsbuildinfo` が `clean` スクリプトで削除されないことによる、TypeScript incremental ビルドのスキップ。

**問題の流れ:**

1. `pnpm install` → `prepare` が `build` を実行 → `dist/` と `tsconfig.build.tsbuildinfo` が生成される
2. `pnpm run build` (ワークフロー) → `clean` で `dist/` を削除するが `tsconfig.build.tsbuildinfo` は残る
3. `tsc -p tsconfig.build.json` → tsbuildinfo が「変更なし」と判断してコンパイルをスキップ → **dist/ が空のまま**
4. `pnpm publish` → `dist/` が存在しないため tarball に含まれない

**ローカル再現確認:**

```sh
# tsbuildinfo あり、dist なし → tsc が dist を生成しない
$ pnpm run clean && pnpm run compile && ls dist 2>/dev/null || echo "dist/ MISSING"
# → dist/ MISSING

# tsbuildinfo も削除 → tsc が正常にフルコンパイル
$ rimraf tsconfig.build.tsbuildinfo && pnpm run compile && ls dist | wc -l
# → 17
```

## 変更内容

### `package.json`

`clean` スクリプトに tsbuildinfo ファイルの削除を追加し、毎回フルコンパイルを強制:

```diff
-"clean": "rimraf dist output"
+"clean": "rimraf dist output tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo"
```

### `.github/workflows/release.yml`

1. **dist 内容の検証ステップを追加**: `dist/index.js` と `dist/index.d.ts` の存在を確認
2. **tarball 内容の検証ステップを追加**: `pnpm pack` で生成した tarball に `dist/` が含まれることを CI で保証
3. **`pnpm publish --ignore-scripts` を使用**: publish 時に `prepare` が再実行されて dist が破壊される経路を遮断
4. pack/publish 分割方式を廃止してシンプルな `pnpm publish --ignore-scripts` に統一

## 動作確認

ローカルで pixivts PR #1577 と同様の方式で検証済み:

```sh
# clean で tsbuildinfo を削除 → build で dist が正しく生成される
$ pnpm run build && ls dist | wc -l
# → 17 ✅

# pnpm pack (prepare あり) でも tarball に dist/ が含まれる
$ pnpm pack --pack-destination /tmp/pack-verify
$ tar -tzf /tmp/pack-verify/*.tgz | grep 'dist/index'
# → package/dist/index.js ✅
# → package/dist/index.d.ts ✅
```

## 関連

- pixivts での同様の修正: book000/pixivts#1577

- Closes #1452