### PR TITLE
fix: Logger.configure()をcategory単位でキャッシュし、ファイルディスクリプタリークを防止する

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -151,10 +151,10 @@ describe('Logger', () => {
       process.env.LOG_LEVEL = 'debug'
       Logger.configure('cache-test-env')
 
-      // 2回目の呼び出しではWinstonDailyRotateFile / createLoggerが再度呼ばれない
+      // 2 回目の呼び出しでは WinstonDailyRotateFile / createLogger が再度呼ばれない
       expect(winston.createLogger).toHaveBeenCalledTimes(1)
       expect(WinstonDailyRotateFile).toHaveBeenCalledTimes(1)
-      // 1回目呼び出し時点ではLOG_LEVEL未設定だったため、デフォルト値のままである
+      // 1 回目呼び出し時点では LOG_LEVEL 未設定だったため、デフォルト値のままである
       expect(winston.transports.Console).toHaveBeenCalledWith(
         expect.objectContaining({
           level: 'info',

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -128,6 +128,49 @@ describe('Logger', () => {
       expect(logger).toBeInstanceOf(Logger)
     })
 
+    it('should return the cached instance for the same category on second call', () => {
+      const first = Logger.configure('cache-test')
+      const second = Logger.configure('cache-test')
+
+      expect(second).toBe(first)
+      expect(winston.createLogger).toHaveBeenCalledTimes(1)
+    })
+
+    it('should create separate instances for different categories', () => {
+      const first = Logger.configure('cache-test-a')
+      const second = Logger.configure('cache-test-b')
+
+      expect(second).not.toBe(first)
+      expect(winston.createLogger).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not reflect environment variable changes on a cached category', () => {
+      Logger.configure('cache-test-env')
+
+      process.env.LOG_LEVEL = 'debug'
+      Logger.configure('cache-test-env')
+
+      // 2回目の呼び出しではWinstonDailyRotateFile / createLoggerが再度呼ばれない
+      expect(winston.createLogger).toHaveBeenCalledTimes(1)
+      expect(WinstonDailyRotateFile).toHaveBeenCalledTimes(1)
+      // 1回目呼び出し時点ではLOG_LEVEL未設定だったため、デフォルト値のままである
+      expect(winston.transports.Console).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'info',
+        })
+      )
+    })
+
+    // NOTE: Task 2 で Logger.resetForTesting() を実装後にコメントアウトを解除する
+    // it('should create a new instance after resetForTesting is called', () => {
+    //   const first = Logger.configure('cache-test-reset')
+    //   Logger.resetForTesting()
+    //   const second = Logger.configure('cache-test-reset')
+    //
+    //   expect(second).not.toBe(first)
+    //   expect(winston.createLogger).toHaveBeenCalledTimes(2)
+    // })
+
     it('should use LOG_LEVEL environment variable when provided', () => {
       process.env.LOG_LEVEL = 'debug'
 

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -39,6 +39,7 @@ jest.mock('winston', () => {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    close: jest.fn(),
   }
 
   return {
@@ -169,6 +170,16 @@ describe('Logger', () => {
 
       expect(second).not.toBe(first)
       expect(winston.createLogger).toHaveBeenCalledTimes(2)
+    })
+
+    it('should close cached winston loggers when resetForTesting is called', () => {
+      const instance = Logger.configure('cache-test-close')
+      const mockLogger = winston.createLogger({ transports: [] })
+
+      Logger.resetForTesting()
+
+      expect(mockLogger.close).toHaveBeenCalled()
+      expect(instance).toBeInstanceOf(Logger)
     })
 
     it('should use LOG_LEVEL environment variable when provided', () => {

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -93,6 +93,7 @@ describe('Logger', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    Logger.resetForTesting()
     process.env = { ...originalEnv }
     // 環境変数を初期化
     delete process.env.LOG_LEVEL
@@ -161,15 +162,14 @@ describe('Logger', () => {
       )
     })
 
-    // NOTE: Task 2 で Logger.resetForTesting() を実装後にコメントアウトを解除する
-    // it('should create a new instance after resetForTesting is called', () => {
-    //   const first = Logger.configure('cache-test-reset')
-    //   Logger.resetForTesting()
-    //   const second = Logger.configure('cache-test-reset')
-    //
-    //   expect(second).not.toBe(first)
-    //   expect(winston.createLogger).toHaveBeenCalledTimes(2)
-    // })
+    it('should create a new instance after resetForTesting is called', () => {
+      const first = Logger.configure('cache-test-reset')
+      Logger.resetForTesting()
+      const second = Logger.configure('cache-test-reset')
+
+      expect(second).not.toBe(first)
+      expect(winston.createLogger).toHaveBeenCalledTimes(2)
+    })
 
     it('should use LOG_LEVEL environment variable when provided', () => {
       process.env.LOG_LEVEL = 'debug'

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -94,7 +94,7 @@ describe('Logger', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    Logger.resetForTesting()
+    Logger.closeAll()
     process.env = { ...originalEnv }
     // 環境変数を初期化
     delete process.env.LOG_LEVEL
@@ -163,20 +163,20 @@ describe('Logger', () => {
       )
     })
 
-    it('should create a new instance after resetForTesting is called', () => {
+    it('should create a new instance after closeAll is called', () => {
       const first = Logger.configure('cache-test-reset')
-      Logger.resetForTesting()
+      Logger.closeAll()
       const second = Logger.configure('cache-test-reset')
 
       expect(second).not.toBe(first)
       expect(winston.createLogger).toHaveBeenCalledTimes(2)
     })
 
-    it('should close cached winston loggers when resetForTesting is called', () => {
+    it('should close cached winston loggers when closeAll is called', () => {
       const instance = Logger.configure('cache-test-close')
       const mockLogger = winston.createLogger({ transports: [] })
 
-      Logger.resetForTesting()
+      Logger.closeAll()
 
       expect(mockLogger.close).toHaveBeenCalled()
       expect(instance).toBeInstanceOf(Logger)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -72,6 +72,10 @@ export class Logger {
    * (環境変数を変更していても再生成されない)。これにより、ループや高頻度呼び出しによる
    * ファイルディスクリプタリークを防止する。
    *
+   * 内部キャッシュは category ごとに自動解放されないため、ユーザー ID やリクエスト ID など
+   * 高カーディナリティな値を category に使うとキャッシュが無制限に肥大化する。category には
+   * クラス名・モジュール名など固定かつ低カーディナリティな値を指定すること。
+   *
    * 環境変数で以下の設定が可能 (初回呼び出し時のみ反映される)
    * - LOG_LEVEL: ログレベル (デフォルト info)
    * - LOG_FILE_LEVEL: ファイル出力のログレベル (デフォルト info)
@@ -188,9 +192,14 @@ export class Logger {
    * テスト用途: 内部キャッシュをクリアする
    *
    * category ごとの Logger インスタンスキャッシュを破棄し、次回の configure() 呼び出しで
-   * 新規に生成し直させる。プロダクションコードから呼び出すことは想定していない。
+   * 新規に生成し直させる。破棄前にキャッシュ済みの各 winston Logger (トランスポート含む) を
+   * close() し、実トランスポートを使うテストで open handle が残らないようにする。
+   * プロダクションコードから呼び出すことは想定していない。
    */
   public static resetForTesting(): void {
+    for (const instance of this.cache.values()) {
+      instance.logger.close()
+    }
     this.cache.clear()
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -189,14 +189,15 @@ export class Logger {
   }
 
   /**
-   * テスト用途: 内部キャッシュをクリアする
+   * キャッシュされている全ての Logger を close() し、内部キャッシュをクリアする
    *
-   * category ごとの Logger インスタンスキャッシュを破棄し、次回の configure() 呼び出しで
-   * 新規に生成し直させる。破棄前にキャッシュ済みの各 winston Logger (トランスポート含む) を
-   * close() し、実トランスポートを使うテストで open handle が残らないようにする。
-   * プロダクションコードから呼び出すことは想定していない。
+   * category ごとにキャッシュされた各 winston Logger (トランスポート含む) を明示的に
+   * close() してからキャッシュを破棄するため、次回の configure() 呼び出しでは
+   * category ごとに新規インスタンスが生成し直される。プロセス終了処理や、テスト間で
+   * ロガーの状態をリセットしたい場合など、キャッシュ済みロガーのファイルディスクリプタを
+   * まとめて解放したいときに使用する。
    */
-  public static resetForTesting(): void {
+  public static closeAll(): void {
     for (const instance of this.cache.values()) {
       instance.logger.close()
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,6 +17,8 @@ const getTimestampFormatter = (): string => {
 }
 
 export class Logger {
+  private static readonly cache = new Map<string, Logger>()
+
   private readonly logger: winston.Logger
 
   private constructor(logger: winston.Logger) {
@@ -66,7 +68,11 @@ export class Logger {
   /**
    * ロガーを初期化・設定する
    *
-   * 環境変数で以下の設定が可能
+   * 同一 category に対する 2 回目以降の呼び出しでは、初回生成時のインスタンスをそのまま返す
+   * (環境変数を変更していても再生成されない)。これにより、ループや高頻度呼び出しによる
+   * ファイルディスクリプタリークを防止する。
+   *
+   * 環境変数で以下の設定が可能 (初回呼び出し時のみ反映される)
    * - LOG_LEVEL: ログレベル (デフォルト info)
    * - LOG_FILE_LEVEL: ファイル出力のログレベル (デフォルト info)
    * - LOG_DIR: ログ出力先 (デフォルト logs)。Vercelで動作する場合は /tmp/logs に出力する
@@ -74,9 +80,14 @@ export class Logger {
    * - LOG_FILE_FORMAT: ログファイルのフォーマット (デフォルト text)
    *
    * @param category カテゴリ
-   * @returns ロガー
+   * @returns ロガー (同一 category では既存インスタンスを再利用する)
    */
   public static configure(category: string): Logger {
+    const cached = this.cache.get(category)
+    if (cached) {
+      return cached
+    }
+
     const logLevel = process.env.LOG_LEVEL ?? 'info'
     const logFileLevel = process.env.LOG_FILE_LEVEL ?? 'info'
     const logDirectory = process.env.VERCEL
@@ -168,7 +179,9 @@ export class Logger {
         transportRotateFile,
       ],
     })
-    return new Logger(logger)
+    const instance = new Logger(logger)
+    this.cache.set(category, instance)
+    return instance
   }
 
   static getTimestamp(): () => string {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -184,6 +184,16 @@ export class Logger {
     return instance
   }
 
+  /**
+   * テスト用途: 内部キャッシュをクリアする
+   *
+   * category ごとの Logger インスタンスキャッシュを破棄し、次回の configure() 呼び出しで
+   * 新規に生成し直させる。プロダクションコードから呼び出すことは想定していない。
+   */
+  public static resetForTesting(): void {
+    this.cache.clear()
+  }
+
   static getTimestamp(): () => string {
     // 'YYYY-MM-DD hh:mm:ss.SSS'
     // Asia/Tokyo


### PR DESCRIPTION
## 概要

`Logger.configure(category)` (`src/logger.ts`) は、呼び出すたびに新規の `winston.createLogger()` と新規の `WinstonDailyRotateFile` トランスポート (＝新規ファイルディスクリプタ) を生成していました。同一 `category` に対して繰り返し呼び出しても、直前の呼び出しで生成されたインスタンス・トランスポートは明示的にクローズされず参照だけが破棄されるため、呼び出し回数に応じてファイルディスクリプタが際限なくリークしていました。

`tomacheese/telcheck` では、ループ内で毎回 `Logger.configure('checker')` を呼び出す実装により、起動から約 6 日 17 時間後にファイルディスクリプタが枯渇し `EMFILE: too many open files` が発生。さらに `uncaughtException` ハンドラ内でも `Logger.configure('main')` を呼んでいたため、例外処理自体が連鎖的に失敗し無限ループ化、ログが 312GB まで肥大化する実害が発生していました。

## 変更内容

- `Logger` クラスに `category` をキーとした静的キャッシュ (`Map<string, Logger>`) を追加
- `configure(category)` は、同一 `category` に対する 2 回目以降の呼び出しで、新規の `winston.createLogger()` / `WinstonDailyRotateFile` を生成せず、初回生成済みの `Logger` インスタンスをそのまま返すように変更
  - これにより、ループや高頻度呼び出しによるファイルディスクリプタリークを防止
  - キャッシュキーは `category` のみ。環境変数 (`LOG_LEVEL` 等) を変更してから同一 `category` で再度呼び出しても、初回生成時の設定を維持したインスタンスが返る (再読込・再生成は行わない)
  - JSDoc に、category には固定・低カーディナリティな値を使うこと (ユーザー ID やリクエスト ID のような値は避けること) を明記
- `Logger.closeAll()` (public static) を追加
  - キャッシュされている全ての `Logger` (winston Logger・トランスポート含む) を `close()` してから内部キャッシュをクリアする
  - プロセス終了処理やテスト間でロガーの状態をリセットしたい場合など、キャッシュ済みロガーのファイルディスクリプタをまとめて解放したいときに使用する正式な API
- `src/__tests__/logger.test.ts` に以下を追加
  - `beforeEach` での `Logger.closeAll()` 呼び出し (各テストケースのキャッシュ独立性を担保)
  - 同一 `category` でのキャッシュ再利用を検証するテスト
  - 異なる `category` では別インスタンスが生成されることを検証するテスト
  - キャッシュ後に環境変数を変更しても反映されないことを検証するテスト
  - `closeAll()` 呼び出し後に新規インスタンスが生成されることを検証するテスト
  - `closeAll()` 呼び出し時にキャッシュ済み winston Logger が `close()` されることを検証するテスト

## スコープ外 (今回対応しないこと)

- category 単位で個別に破棄できる `close(category)` の追加 (今回追加した `closeAll()` は全キャッシュ一括破棄のみ。category 単位の破棄が必要になった場合は別途検討する)
- `uncaughtException` / `unhandledRejection` ハンドラの実装変更 (今回のキャッシュ導入により `Logger.configure('main')` は初回呼び出し以降キャッシュされたインスタンスを返すようになるため、既存コードの変更なしで例外処理の連鎖的失敗が解消される)
- category ごとに異なる設定を動的に切り替える機能

## 動作確認

- `pnpm lint`: エラーなし
- `pnpm test` (jest --coverage): 全 70 テスト成功。`logger.ts` のカバレッジは 98.3% stmts / 97.5% branch / 93.33% funcs / 100% lines

## レビュー対応

GitHub Copilot のレビューで以下2点の指摘があり、対応済み:
- キャッシュ破棄前に winston Logger の `close()` を呼んでいなかった点 → `closeAll()` (実装当初は `resetForTesting()`) でキャッシュ破棄前に `close()` するよう修正
- category に高カーディナリティな値を使うとキャッシュが無制限に肥大化する懸念 → JSDoc に注意書きを追加

上記対応の過程で、当初 "テスト用途" として実装した `resetForTesting()` が実質的に `close()` 相当の処理を行っていたため、実態に即して `closeAll()` にリネームし、プロダクションでも利用できる正式な API として文書化した。

Closes #1533